### PR TITLE
/events/YYYY/MM/:slug as canonical event URL

### DIFF
--- a/models.js
+++ b/models.js
@@ -98,7 +98,6 @@ module.exports = function(debug) {
 		},
 		key: { type: sequelize.TEXT },
 		importid: { type: sequelize.TEXT },
-
 	}, {
 		timestamps: false,
 		createdAt: false,
@@ -106,6 +105,14 @@ module.exports = function(debug) {
 		instanceMethods: {
 			blurbAsHTML: function() {
 				return marked(this.blurb);
+			},
+		},
+		getterMethods: {
+			absolute_url: function() {
+				var url = moment(this.getDataValue('startdt')).format('[/]YYYY[/]MM/') + this.getDataValue('slug');
+				return '/event'
+					+ moment(this.getDataValue('startdt')).format('[/]YYYY[/]MM/')
+					+ this.getDataValue('slug');
 			}
 		}
 	});

--- a/routes/event.js
+++ b/routes/event.js
@@ -7,11 +7,25 @@ router.param('id', function(req, res, next, id) {
 
 	models.Event.find({
 		where: { id: id }
-	}).then(function(event) {
-		if (!event)
+	}).then(function(event_) {
+		if (!event_)
 			return next(new Error("No such event"));
 
-		req.event = event;
+		req.event_ = event_;
+	}).then(next, function (err) {
+		next(err);
+	});
+})
+
+router.param('slug', function(req, res, next, slug) {
+	var models = req.app.get('models');
+
+	models.Event.find({
+		where: { slug: slug }
+	}).then(function(event_) {
+		if (!event_)
+			return next(new Error("No such event_"));
+		req.event_ = event_;
 	}).then(next, function (err) {
 		next(err);
 	});
@@ -19,7 +33,7 @@ router.param('id', function(req, res, next, id) {
 
 /* GET event add */
 router.get('/add', function(req, res) {
-	res.render('event_add', { event: req.event });
+	res.render('event_add', { event: req.event_ });
 });
 
 /* POST event add */
@@ -43,7 +57,7 @@ router.post('/add', function(req, res) {
 		.then(function(event_) {
 			console.log('ok');
 			console.log(event_);
-			res.redirect(event_.id);
+			res.redirect(event_.absolute_url);
 		})
 		.catch(function(errors) {
 			console.log(errors);
@@ -55,9 +69,15 @@ router.post('/add', function(req, res) {
 		});
 });
 
-/* GET home page. */
+/* GET event by ID */
 router.get('/:id', function(req, res) {
-	res.render('event_page', { event: req.event });
+	console.log(req.event_.absolute_url);
+	res.redirect(req.event_.absolute_url);
+});
+
+/* GET event by slug */
+router.get('/:year/:month/:slug', function(req, res) {
+	res.render('event_page', { event: req.event_ });
 });
 
 module.exports = router;

--- a/views/index.html
+++ b/views/index.html
@@ -10,7 +10,6 @@
 <h2>Events</h2>
 
 {% for chunk in events %}
-
 	{% if chunk.shortDate %}
 		<h3>{{ chunk.shortDate }} <small>{{ chunk.longDate }}</small></h3>
 	{% else %}
@@ -21,7 +20,7 @@
 		{% if loop.first %}
 
 		<div class="event event-expanded">
-			<h4><b>{{ event.startdt.format("ha") }}</b>, <a href="/event/{{ event.id }}">{{ event.title }}</a></h4>
+			<h4><b>{{ event.startdt.format("ha") }}</b>, <a href="{{ event.absolute_url }}">{{ event.title }}</a></h4>
 			<p><i class="fa fa-map-marker"></i> {{ event.location }}
 			<p>{{ event.blurbAsHTML() }}
 			<p>more info at <i class="fa fa-external-link"></i>
@@ -31,7 +30,7 @@
 		{% else %}
 
 		<div class="event">
-		<h4><b>{{ event.startdt.format("ha") }}</b>, <a href="/event/{{ event.id }}">{{ event.title }}</a></h4>
+		<h4><b>{{ event.startdt.format("ha") }}</b>, <a href="{{ event.absolute_url }}">{{ event.title }}</a></h4>
 		</div>
 
 		{% endif %}


### PR DESCRIPTION
Closes #7 

Adds:

 *  'pseudo' property (scare quotes from Sequelize docs) called `absolute_url` which returns the appropriate value
 * `:slug` url param processor (mostly copy-pasted from the `:id` one)
 *  redirect from `/events/:id` to `/events/YYYY/MM/:slug`