### PR TITLE
Pagination in admin events list

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ var bodyParser = require('body-parser');
 var swig = require('swig');
 var markedSwig = require('swig-marked');
 var passport = require('passport');
+var paginate = require('express-paginate');
 
 var models = require('./models');
 
@@ -46,6 +47,7 @@ app.use(session({
 app.use(flash());
 app.use(passport.initialize());
 app.use(passport.session());
+app.use(paginate.middleware());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/bower_components', express.static(path.join(__dirname, 'bower_components')));
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sqlite3": "^3.0.2",
     "swig": "^1.4.2",
     "swig-email-templates": "~1.3.0",
-    "swig-marked": "0.0.1"
+    "swig-marked": "0.0.1",
+    "express-paginate": "0.0.6"
   }
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -59,17 +59,20 @@ router.param('location_id', function(req, res, next, loc_id) {
 })
 
 router.get('/', ensureEditorOrAdmin, function(req, res) {
-	models.Event.findAll({
+	models.Event.findAndCountAll({
 		where: [
 			{ state: ["submitted", "imported"] }
 		],
 		include: [ models.Location ],
-		limit: 20,
+		limit: req.query.limit,
+		offset: req.query.limit * req.query.page,
 		order: "startdt ASC"
-	}).then(function(events_) {
+	}).then(function(result) {
 		res.render('admin', {
 			user: req.user,
-			events_: events_
+			events_: result.rows,
+			pageCount: Math.floor(result.count / req.query.limit),
+			itemCount: result.count
 		});
 	});
 });

--- a/views/_paginate.html
+++ b/views/_paginate.html
@@ -1,0 +1,17 @@
+{% if paginate.hasPreviousPages or paginate.hasNextPages(pageCount) %}
+<div class="navigation well-sm" id="pagination">
+	<ul class="pager">
+  {% if paginate.hasPreviousPages %}
+  	<li class="previous"><a href="{{ paginate.href(true) }}" class="prev">
+			<i class="fa fa-arrow-circle-left">Previous</i>
+		</a></li>
+	{% endif %}
+	{# FIXME: loop over pages to draw per-page links #}
+  {% if paginate.hasNextPages(pageCount) %}
+  	<li class="next"><a href="{{ paginate.href() }}" class="prev">
+			<i class="fa fa-arrow-circle-right">Next</i>
+		</a></li>
+	{% endif %}
+	</ul>
+</div>
+{% endif %}

--- a/views/admin.html
+++ b/views/admin.html
@@ -6,60 +6,62 @@
 {% block content %}
 <div>
 
-<ol class="breadcrumb">
-  <li><a href="/">Echo</a></li>
-  <li><a href="/admin">Admin</a></li>
-</ol>
+	<ol class="breadcrumb">
+		<li><a href="/">Echo</a></li>
+		<li><a href="/admin">Admin</a></li>
+	</ol>
 
-{{ checkMessages() }}
+	{{ checkMessages() }}
 
-<h2>Administration</h2>
-<p>
-	Welcome to the admin area. Have fun!
-</p>
+	<h2>Administration</h2>
+	<p>
+		Welcome to the admin area. Have fun!
+	</p>
 
-<h3>Events awaiting moderation</h3>
+	<h3>Events awaiting moderation</h3>
 
-<table class="table">
-	<tr>
-		<th>id</th>
-		<th>title</th>
-		<th>start</th>
-		<th>end</th>
-		<th>location</th>
-		<th>host</th>
-		<th>url</th>
-		<th>state</th>
-		<th>actions</th>
-	</tr>
-	{% for event in events_ %}
-	<tr>
-		<td><a href="/admin/event/{{ event.id }}">{{ event.id }}</a></td>
-		<td>{{ event.title }}</td>
-		<td>{{ event.startdt.format("YYYY-MM-DD ha") }}</td>
-		<td>{% if event.enddt.isValid() %}
-			{{ event.enddt.format("YYYY-MM-DD ha") }}
-		{% else %}
-			<i>(not set)</i>
-		{% endif %}</td>
-		<td>{{ event.shortLocation }}</td>
-		<td>{{ event.host }}</td>
-		<td>{{ event.url }}</td>
-		<td>{{ event.state }}</td>
-		<td>
-			<a href="/admin/event/{{ event.id }}/edit" class="btn btn-xs btn-info">
-				edit
-			</a>
-			<a href="/admin/event/{{ event.id }}/approve" class="btn btn-xs btn-success">
-				approve
-			</a>
-			<a href="/admin/event/{{ event.id }}/reject" class="btn btn-xs btn-warning">
-				reject
-			</a>
-		</td>
-	</tr>
-	{% endfor %}
-</table>
+	<table class="table">
+		<tr>
+			<th>id</th>
+			<th>title</th>
+			<th>start</th>
+			<th>end</th>
+			<th>location</th>
+			<th>host</th>
+			<th>url</th>
+			<th>state</th>
+			<th>actions</th>
+		</tr>
+		{% for event in events_ %}
+		<tr>
+			<td><a href="/admin/event/{{ event.id }}">{{ event.id }}</a></td>
+			<td>{{ event.title }}</td>
+			<td>{{ event.startdt.format("YYYY-MM-DD ha") }}</td>
+			<td>{% if event.enddt.isValid() %}
+				{{ event.enddt.format("YYYY-MM-DD ha") }}
+			{% else %}
+				<i>(not set)</i>
+			{% endif %}</td>
+			<td>{{ event.shortLocation }}</td>
+			<td>{{ event.host }}</td>
+			<td>{{ event.url }}</td>
+			<td>{{ event.state }}</td>
+			<td>
+				<a href="/admin/event/{{ event.id }}/edit" class="btn btn-xs btn-info">
+					edit
+				</a>
+				<a href="/admin/event/{{ event.id }}/approve" class="btn btn-xs btn-success">
+					approve
+				</a>
+				<a href="/admin/event/{{ event.id }}/reject" class="btn btn-xs btn-warning">
+					reject
+				</a>
+			</td>
+		</tr>
+		{% endfor %}
+	</table>
+
+	{% include "_paginate.html" %}
 
 </div>
 {% endblock %}


### PR DESCRIPTION
Implemented using [express-paginate](https://github.com/expressjs/express-paginate) and a couple of extra fields on the `Events` sequelize query (no sequelize pagination plugin available).

Defaults to 10 items per page, max 50 (can only be changed in the URL for the moment).

No per-page links yet, pending a `range` template filter (see [SWIG #497](https://github.com/paularmstrong/swig/issues/497)) or a clean way of turning `pageCount` into a list of numbers.

Closes #21 

